### PR TITLE
Move set construction from predicate methods to constants to optimize

### DIFF
--- a/src/main/java/danta/aem/contextprocessors/AddAllResourceContentPropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddAllResourceContentPropertiesContextProcessor.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 
 import javax.jcr.Node;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -52,9 +53,11 @@ import static danta.core.Constants.XK_CONTENT_ID_CP;
 public class AddAllResourceContentPropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(CONTENT_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(CONTENT_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/AddBasicResourcePropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddBasicResourcePropertiesContextProcessor.java
@@ -30,6 +30,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 
 import javax.jcr.Node;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -50,9 +51,11 @@ import static danta.core.Constants.XK_CONTENT_ID_CP;
 public class AddBasicResourcePropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(CONTENT_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(CONTENT_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/AddComponentPropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddComponentPropertiesContextProcessor.java
@@ -35,6 +35,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 
 import javax.jcr.Node;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -55,14 +56,16 @@ import static danta.core.util.ObjectUtils.wrap;
 public class AddComponentPropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
-    @Reference(cardinality = ReferenceCardinality.MANDATORY_UNARY, policy = ReferencePolicy.STATIC)
-    private ResourceResolverFactory resourceResolverFactory;
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(COMPONENT_CATEGORY));
 
     private static final String CONFIG_SERVICE = "config-service";
 
+    @Reference(cardinality = ReferenceCardinality.MANDATORY_UNARY, policy = ReferencePolicy.STATIC)
+    private ResourceResolverFactory resourceResolverFactory;
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(COMPONENT_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/AddDesignPropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddDesignPropertiesContextProcessor.java
@@ -32,6 +32,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -52,9 +53,11 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddDesignPropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl>  {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(DESIGN_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(DESIGN_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/AddGlobalPropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddGlobalPropertiesContextProcessor.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -50,9 +51,11 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddGlobalPropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(GLOBAL_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(GLOBAL_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/AddPagePropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddPagePropertiesContextProcessor.java
@@ -42,6 +42,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 
 import javax.jcr.Node;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -63,12 +64,14 @@ import static danta.core.Constants.XK_CONTAINER_CLASSES_CP;
 public class AddPagePropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(PAGE_CATEGORY));
+
     @Reference(cardinality = ReferenceCardinality.MANDATORY_UNARY, policy = ReferencePolicy.STATIC)
     protected AssetPathService assetPathService;
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(PAGE_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/AddSlingModelsPropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddSlingModelsPropertiesContextProcessor.java
@@ -56,13 +56,15 @@ import static danta.aem.Constants.*;
 public class AddSlingModelsPropertiesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModel> {
 
-    @Override
-    public Set<String> anyOf() {
-        return Sets.newHashSet(SLING_MODELS_CATEGORY);
-    }
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(SLING_MODELS_CATEGORY));
 
     @Reference
-    private ModelFactory modelFactory = null;
+    private ModelFactory modelFactory;
+
+    @Override
+    public Set<String> anyOf() {
+        return ANY_OF;
+    }
 
     @Override
     public int priority() {

--- a/src/main/java/danta/aem/contextprocessors/AddSlingModelsPropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddSlingModelsPropertiesContextProcessor.java
@@ -35,7 +35,14 @@ import org.apache.sling.models.factory.ModelFactory;
 
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import static danta.Constants.DOT;
 import static danta.Constants.HIGHEST_PRIORITY;

--- a/src/main/java/danta/aem/contextprocessors/AddStylingContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddStylingContextProcessor.java
@@ -31,6 +31,7 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -80,9 +81,11 @@ import static danta.core.Constants.*;
 public class AddStylingContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(STYLING_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(STYLING_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/DeserializeJSONPropertyValuesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/DeserializeJSONPropertyValuesContextProcessor.java
@@ -31,6 +31,7 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.COMPONENT_CATEGORY;
@@ -76,9 +77,11 @@ import static danta.core.Constants.XK_DESERIALIZE_JSON_PROPS_CP;
 public class DeserializeJSONPropertyValuesContextProcessor
         extends AbstractCheckComponentCategoryContextProcessor<TemplateContentModelImpl> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(COMPONENT_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(COMPONENT_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/images/AbstractImageContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AbstractImageContextProcessor.java
@@ -24,6 +24,7 @@ import danta.core.contextprocessors.AbstractCheckComponentCategoryContextProcess
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.IMAGE_CATEGORY;
@@ -41,8 +42,10 @@ public abstract class AbstractImageContextProcessor<C extends ContentModel>
         extends AbstractCheckComponentCategoryContextProcessor<C>
         implements ImageContextProcessor<C> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(IMAGE_CATEGORY));
+
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(IMAGE_CATEGORY);
+        return ANY_OF;
     }
 }

--- a/src/main/java/danta/aem/contextprocessors/images/AddMultipleTransformedImagePathsFromResourcesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AddMultipleTransformedImagePathsFromResourcesContextProcessor.java
@@ -33,6 +33,7 @@ import org.apache.sling.api.resource.Resource;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -54,12 +55,14 @@ import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
 public class AddMultipleTransformedImagePathsFromResourcesContextProcessor
         extends AbstractImageContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(MULTIPLE_IMAGE_RESOURCES_CATEGORY));
+
     @Reference
     AssetPathService assetPathService;
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(MULTIPLE_IMAGE_RESOURCES_CATEGORY);
+        return ANY_OF;
     }
 
     private final Predicate<Resource> IMAGE_RESOURCES_PREDICATE = new Predicate<Resource>() {

--- a/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathContextProcessor.java
@@ -28,6 +28,7 @@ import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.*;
@@ -45,12 +46,14 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddTransformedImagePathContextProcessor
         extends AbstractImageContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(CONTENT_IMAGE_CATEGORY));
+
     @Reference
     AssetPathService assetPathService;
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(CONTENT_IMAGE_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathFromDesignContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathFromDesignContextProcessor.java
@@ -32,6 +32,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.*;
@@ -49,12 +50,14 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddTransformedImagePathFromDesignContextProcessor
         extends AbstractImageContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(DESIGN_IMAGE_CATEGORY));
+
     @Reference
     private AssetPathService assetPathService;
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(DESIGN_IMAGE_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathFromGlobalContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathFromGlobalContextProcessor.java
@@ -30,6 +30,7 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.*;
@@ -48,7 +49,9 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddTransformedImagePathFromGlobalContextProcessor
         extends AbstractImageContextProcessor<TemplateContentModel> {
 
-    public static final String CONFIG_GLOBAL_IMAGE_KEY = CONFIG_PROPERTIES_KEY + DOT + "xk_globalImagePath";
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(GLOBAL_IMAGE_CATEGORY));
+
+    private static final String CONFIG_GLOBAL_IMAGE_KEY = CONFIG_PROPERTIES_KEY + DOT + "xk_globalImagePath";
     private static final String COMPONENT_GLOBAL_DIALOG_PATH = COMPONENT_PROPERTIES_KEY + DOT + GLOBAL_PATH_PROPERTY_KEY;
 
     @Reference
@@ -56,7 +59,7 @@ public class AddTransformedImagePathFromGlobalContextProcessor
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(GLOBAL_IMAGE_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathsContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AddTransformedImagePathsContextProcessor.java
@@ -31,6 +31,7 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,12 +55,14 @@ import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
 public class AddTransformedImagePathsContextProcessor
         extends AbstractImageContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(IMAGES_BY_KEY_CATEGORY));
+
     @Reference
     AssetPathService assetPathService;
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(IMAGES_BY_KEY_CATEGORY);
+        return ANY_OF;
     }
 
     private final Predicate<Resource> IMAGE_RESOURCES_PREDICATE = new Predicate<Resource>() {

--- a/src/main/java/danta/aem/contextprocessors/images/AddTransformedMultipleImagePathsContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/images/AddTransformedMultipleImagePathsContextProcessor.java
@@ -32,6 +32,7 @@ import org.apache.sling.api.resource.Resource;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.*;
@@ -49,12 +50,14 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddTransformedMultipleImagePathsContextProcessor
         extends AbstractImageContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(MULTIPLE_IMAGE_CATEGORY));
+
     @Reference
     AssetPathService assetPathService;
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(MULTIPLE_IMAGE_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/lists/AbstractItemListContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/lists/AbstractItemListContextProcessor.java
@@ -25,6 +25,7 @@ import danta.core.util.NumberUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
 
+import java.util.Collections;
 import java.util.Set;
 
 import static danta.Constants.HIGHER_PRIORITY;
@@ -43,11 +44,13 @@ public abstract class AbstractItemListContextProcessor<C extends ContentModel>
         extends AbstractCheckComponentCategoryContextProcessor<C>
         implements ListContextProcessor<C> {
 
+    private static final Set<String> ANY_OF = Collections.unmodifiableSet(Sets.newHashSet(LIST_CATEGORY));
+
     protected static final int PRIORITY = NumberUtils.nextPrime(HIGHER_PRIORITY - 20);
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(LIST_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/lists/AddCuratedPageReferencesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/lists/AddCuratedPageReferencesContextProcessor.java
@@ -28,6 +28,7 @@ import org.apache.felix.scr.annotations.Service;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,11 +46,14 @@ import static danta.Constants.*;
 public class AddCuratedPageReferencesContextProcessor
         extends AbstractItemListContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ALL_OF =
+            Collections.unmodifiableSet(Sets.newHashSet(LIST_CATEGORY, CURATED_LIST_CATEGORY));
+
     public static final int PRIORITY = AddItemListContextProcessor.PRIORITY - 20;
 
     @Override
     public Set<String> allOf() {
-        return Sets.newHashSet(LIST_CATEGORY, CURATED_LIST_CATEGORY);
+        return ALL_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/lists/AddPageDetailsContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/lists/AddPageDetailsContextProcessor.java
@@ -49,16 +49,20 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddPageDetailsContextProcessor
         extends AbstractPageDetailsContextProcessor {
 
+    private static final Set<String> ALL_OF = Collections.unmodifiableSet(Sets.newHashSet(PAGE_DETAILS_CATEGORY));
+    private static final Set<String> ANY_OF =
+            Collections.unmodifiableSet(Sets.newHashSet(CURATED_LIST_CATEGORY, TRAVERSED_LIST_CATEGORY));
+
     protected static final int PRIORITY = AddCuratedPageReferencesContextProcessor.PRIORITY - 20;
 
     @Override
     public Set<String> allOf() {
-        return Sets.newHashSet(PAGE_DETAILS_CATEGORY);
+        return ALL_OF;
     }
 
     @Override
     public Set<String> anyOf() {
-        return Sets.newHashSet(CURATED_LIST_CATEGORY, TRAVERSED_LIST_CATEGORY);
+        return ANY_OF;
     }
 
     @Override

--- a/src/main/java/danta/aem/contextprocessors/lists/AddTraversedPageReferencesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/lists/AddTraversedPageReferencesContextProcessor.java
@@ -35,6 +35,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -53,11 +54,13 @@ import static danta.aem.Constants.SLING_HTTP_REQUEST;
 public class AddTraversedPageReferencesContextProcessor
         extends AbstractItemListContextProcessor<TemplateContentModel> {
 
+    private static final Set<String> ALL_OF = Collections.unmodifiableSet(Sets.newHashSet(TRAVERSED_LIST_CATEGORY));
+
     protected static final int PRIORITY = AddItemListContextProcessor.PRIORITY - 20;
 
     @Override
     public Set<String> allOf() {
-        return Sets.newHashSet(TRAVERSED_LIST_CATEGORY);
+        return ALL_OF;
     }
 
     @Override


### PR DESCRIPTION
Code optimization so these constant sets are not constructed on every single request.  The constants are wrapped in an unmodifiableSet to ensure these sets aren't changed elsewhere.

DantaFramework/AEMDemo#3 will make the same change to the demo CPs.