### PR TITLE
Synchronize the common set method for thread-safety

### DIFF
--- a/src/main/java/danta/aem/templating/TemplateContentModelImpl.java
+++ b/src/main/java/danta/aem/templating/TemplateContentModelImpl.java
@@ -125,7 +125,7 @@ public class TemplateContentModelImpl
         return this;
     }
 
-    private TemplateContentModelImpl set(final Context context, final String path, final Object value) {
+    private synchronized TemplateContentModelImpl set(final Context context, final String path, final Object value) {
         List<String> keys = parsePath(path);
         StringBuilder builtPath = new StringBuilder();
         Map<String, Object> modelDataObj = scopeDataFor(context);


### PR DESCRIPTION
This is not ideal, because it requires all future ContentModel implementations to also ensure their set method is synchronized.  Unfortunately, `ContextProcessorEngineImpl` cannot simply apply a thread-safe wrapper to the ContentModel, since some CPs downcast to the concrete `TemplateContentModelImpl` implementation.  I have not done enough investigation to determine why that is required, but this should certainly be revisited because it is likely like a violation of SOLID principles.

It's also not clear if making this single private `set(Context,String, Object)` method synchronized is sufficient, or if we should make all public `set` variants synchronized as well.  All but `setAsIsolated` delegate to the private method, so I think this is sufficient.  Perhaps it is better to be safe than sorry however.

Though this should not be considered a final solution, I think it is enough to fix DantaFramework/Core#5 for now.