### PR TITLE
Cleaning up template content model implementation

### DIFF
--- a/src/main/java/danta/aem/templating/IncludeResourceHelperFunction.java
+++ b/src/main/java/danta/aem/templating/IncludeResourceHelperFunction.java
@@ -25,6 +25,7 @@ import danta.core.util.UrlUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.*;
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.api.resource.Resource;
@@ -37,7 +38,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.IOException;
+import java.io.CharArrayWriter;
+import java.io.PrintWriter;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -137,13 +141,29 @@ public class IncludeResourceHelperFunction
             com.day.cq.wcm.api.components.Component component = componentManager.getComponentOfResource(resource);
 
             dispatcher = request.getRequestDispatcher(resource, opts);
-            HttpServletResponse wrappedResponse = contentModel().wrappedResponse();
+            HttpServletResponse wrappedResponse = wrapResponse(contentModel().response());
             dispatcher.include(request, wrappedResponse);
             responseString = wrappedResponse.toString();
         } else {
             LOG.error("{} It is not valid", path);
         }
         return new Handlebars.SafeString(responseString);
+    }
+
+    private final HttpServletResponse wrapResponse(HttpServletResponse response) {
+        HttpServletResponseWrapper wrappedResponse = new HttpServletResponseWrapper(response) {
+            final CharArrayWriter output = new CharArrayWriter();
+
+            public String toString() {
+                return output.toString();
+            }
+
+            public PrintWriter getWriter() {
+                return new PrintWriter(output);
+            }
+        };
+
+        return wrappedResponse;
     }
 
     private final String attachSuffixOrPrefix(String path, String prefix, String suffix) {

--- a/src/main/java/danta/aem/templating/IncludeResourceHelperFunction.java
+++ b/src/main/java/danta/aem/templating/IncludeResourceHelperFunction.java
@@ -25,7 +25,6 @@ import danta.core.util.UrlUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.*;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.api.resource.Resource;

--- a/src/main/java/danta/aem/templating/TemplateContentModelImpl.java
+++ b/src/main/java/danta/aem/templating/TemplateContentModelImpl.java
@@ -65,29 +65,4 @@ public class TemplateContentModelImpl
             throws Exception {
         return response;
     }
-
-    final HttpServletResponse wrappedResponse()
-            throws Exception {
-
-        return new CharResponseWrapper(response());
-    }
-
-    static final class CharResponseWrapper
-            extends HttpServletResponseWrapper {
-
-        private CharArrayWriter output;
-
-        public CharResponseWrapper(HttpServletResponse response) {
-            super(response);
-            output = new CharArrayWriter();
-        }
-
-        public String toString() {
-            return output.toString();
-        }
-
-        public PrintWriter getWriter() {
-            return new PrintWriter(output);
-        }
-    }
 }

--- a/src/main/java/danta/aem/templating/TemplateContentModelImpl.java
+++ b/src/main/java/danta/aem/templating/TemplateContentModelImpl.java
@@ -24,9 +24,6 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
-import java.io.CharArrayWriter;
-import java.io.PrintWriter;
 import java.util.*;
 
 import static danta.aem.Constants.SLING_HTTP_REQUEST;


### PR DESCRIPTION
The workaround for solving the issues with the wrappedResponse method is to:

1. Move the method wrappedResponse to a method in the class IncludeResourceHelperFunction. This will also include moving the functionality of the inner class CharResponseWrapper.
2. Make the class CharResponseWrapper anonymous in the method mentioned above.
