### PR TITLE
Feature/update vanity url property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - Updated implementation of the template content model to extend AbstractTemplateContentModelImpl in the Core project.
+- Updated vanity URL property in page and lists contexts.
 
 ### 1.0.5
 - Changed project groupId from "danta" to "io.tikaltechnologies.danta".

--- a/src/main/java/danta/aem/Constants.java
+++ b/src/main/java/danta/aem/Constants.java
@@ -36,6 +36,7 @@ public class Constants {
     public static final String SLING_FOLDER = "sling:Folder";
     public static final String SLING_RESOURCE_TYPE = "sling:resourceType";
     public static final String SLING_RESOURCE_SUPER_TYPE = "sling:resourceSuperType";
+    public static final String SLING_VANITY_PATH = "sling:vanityPath";
     public static final String FOUNDATION_IMAGE_COMPONENT_RESOURCE_TYPE = "foundation/components/image";
     public static final String CONTENT_ROOT = "/content";
     public static final String APPS_ROOT = "/apps";

--- a/src/main/java/danta/aem/contextprocessors/AddPagePropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddPagePropertiesContextProcessor.java
@@ -51,6 +51,7 @@ import static danta.aem.Constants.JCR_DESCRIPTION;
 import static danta.aem.Constants.SLING_HTTP_REQUEST;
 import static danta.aem.util.PropertyUtils.propsToMap;
 import static danta.core.Constants.XK_CONTAINER_CLASSES_CP;
+import static danta.aem.util.PageUtils.getVanityURLs;
 
 /**
  * The context processor for adding page properties to content model
@@ -146,10 +147,10 @@ public class AddPagePropertiesContextProcessor
                             pageContent.put(IS_TOUCH_UI_MODE, false);
                         }
 
-                        // Adding vanity path (sling:vanityPath)
-                        String vanityPath = page.getVanityUrl();
-                        if(vanityPath != null) {
-                            pageContent.put(VANITY_PATH, vanityPath);
+                        // Adding vanity path
+                        Object vanityURLs = getVanityURLs(page);
+                        if (vanityURLs != null) {
+                            pageContent.put(VANITY_PATH, vanityURLs);
                         }
 
                         contentModel.set(PAGE_PROPERTIES_KEY, pageContent);

--- a/src/main/java/danta/aem/contextprocessors/AddPagePropertiesContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/AddPagePropertiesContextProcessor.java
@@ -145,6 +145,13 @@ public class AddPagePropertiesContextProcessor
                             pageContent.put(IS_CLASSIC_UI_MODE, true);
                             pageContent.put(IS_TOUCH_UI_MODE, false);
                         }
+
+                        // Adding vanity path (sling:vanityPath)
+                        String vanityPath = page.getVanityUrl();
+                        if(vanityPath != null) {
+                            pageContent.put(VANITY_PATH, vanityPath);
+                        }
+
                         contentModel.set(PAGE_PROPERTIES_KEY, pageContent);
                     }
                 }

--- a/src/main/java/danta/aem/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static danta.Constants.*;
 import static danta.aem.Constants.JCR_CREATED;
 import static danta.aem.Constants.JCR_DESCRIPTION;
+import static danta.aem.util.PageUtils.getVanityURLs;
 
 /**
  * The abstraction context processor for building a map of property object from a page detail
@@ -73,9 +74,10 @@ public abstract class AbstractPageDetailsContextProcessor extends
             if (StringUtils.isNotEmpty(pageImagePath)) {
                 pageDetails.put(IMAGE_PATH, pageImagePath);
             }
-            String vanityPath = page.getVanityUrl();
-            if(vanityPath != null) {
-                pageDetails.put(VANITY_PATH, vanityPath);
+            // Adding vanity path
+            Object vanityURLs = getVanityURLs(page);
+            if (vanityURLs != null) {
+                pageDetails.put(VANITY_PATH, vanityURLs);
             }
 
             if (currentPage.equals(page.getPath())) {

--- a/src/main/java/danta/aem/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
+++ b/src/main/java/danta/aem/contextprocessors/lists/AbstractPageDetailsContextProcessor.java
@@ -74,7 +74,10 @@ public abstract class AbstractPageDetailsContextProcessor extends
                 pageDetails.put(IMAGE_PATH, pageImagePath);
             }
             String vanityPath = page.getVanityUrl();
-            pageDetails.put(VANITY_PATH, null != vanityPath? vanityPath : page.getPath());
+            if(vanityPath != null) {
+                pageDetails.put(VANITY_PATH, vanityPath);
+            }
+
             if (currentPage.equals(page.getPath())) {
                 pageDetails.put(IS_CURRENT_PAGE, true);
             }

--- a/src/main/java/danta/aem/util/PageUtils.java
+++ b/src/main/java/danta/aem/util/PageUtils.java
@@ -25,9 +25,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ValueMap;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Map;
 
 import static danta.Constants.BLANK;
+import static danta.aem.Constants.SLING_VANITY_PATH;
 
 /**
  * Page Utility class, contained generic methods for handling CQ Page.
@@ -145,5 +147,26 @@ public class PageUtils {
             }
         }
         return keywords;
+    }
+
+    /**
+     * Returns the vanity URLs stored in the page node.
+     *
+     * @param page The page object
+     * @return vanityPaths The vanityURLs either as a string or list.
+     */
+    public static Object getVanityURLs(Page page) {
+        Object vanityPath = page.getProperties().get(SLING_VANITY_PATH);
+        if(vanityPath != null) {
+            if(vanityPath.getClass().isArray()) {
+
+                return Arrays.asList((String[]) vanityPath);
+            } else {
+
+                return vanityPath;
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
The vanity property is obtained via the method getVanityUrl() which returns the value of the property _sling:vanityPath_ stored under the page content node.