### PR TITLE
fixed to run on AEM 6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>com.adobe.acs</groupId>
             <artifactId>acs-aem-commons-bundle</artifactId>
-            <version>3.15.0</version>
+            <version>4.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -137,11 +137,13 @@
             <artifactId>org.apache.sling.api</artifactId>
             <version>2.11.0</version>
         </dependency>
+        <!--
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.resource</artifactId>
-            <version>2.9.2</version>
+            <version>3.0.18</version>
         </dependency>
+        -->
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.adapter</artifactId>

--- a/src/main/java/danta/aem/configuration/AEMConfigurationProviderImpl.java
+++ b/src/main/java/danta/aem/configuration/AEMConfigurationProviderImpl.java
@@ -34,7 +34,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.jcr.api.SlingRepository;
-//import org.apache.sling.jcr.resource.JcrResourceUtil;
 import org.osgi.service.component.ComponentContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/danta/aem/servlets/AbstractExtJSONServlet.java
+++ b/src/main/java/danta/aem/servlets/AbstractExtJSONServlet.java
@@ -21,12 +21,12 @@ package danta.aem.servlets;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.commons.json.JSONArray;
 import org.apache.sling.commons.json.JSONException;
 import org.apache.sling.commons.json.JSONObject;
 import org.apache.sling.jcr.api.SlingRepository;
-import org.apache.sling.jcr.resource.JcrResourceResolverFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ public abstract class AbstractExtJSONServlet
     protected SlingRepository repository;
 
     @Reference
-    protected JcrResourceResolverFactory resourceResolverFactory;
+    protected ResourceResolverFactory resourceResolverFactory;
 
     private ThreadLocal<JSONArray> threadLocal;
 

--- a/src/main/java/danta/aem/util/LazyInputStream.java
+++ b/src/main/java/danta/aem/util/LazyInputStream.java
@@ -1,0 +1,90 @@
+package danta.aem.util;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LazyInputStream extends InputStream {
+
+    /** The JCR Value from which the input stream is requested on demand */
+    private final Value value;
+
+    /** The inputstream created on demand, null if not used */
+    private InputStream delegatee;
+
+    public LazyInputStream(Value value) {
+        this.value = value;
+    }
+
+    /**
+     * Closes the input stream if acquired otherwise does nothing.
+     */
+    @Override
+    public void close() throws IOException {
+        if (delegatee != null) {
+            delegatee.close();
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return getStream().available();
+    }
+
+    @Override
+    public int read() throws IOException {
+        return getStream().read();
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return getStream().read(b);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        return getStream().read(b, off, len);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        return getStream().skip(n);
+    }
+
+    @Override
+    public boolean markSupported() {
+        try {
+            return getStream().markSupported();
+        } catch (IOException ioe) {
+            // ignore
+        }
+        return false;
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        try {
+            getStream().mark(readlimit);
+        } catch (IOException ioe) {
+            // ignore
+        }
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        getStream().reset();
+    }
+
+    /** Actually retrieves the input stream from the underlying JCR Value */
+    private InputStream getStream() throws IOException {
+        if (delegatee == null) {
+            try {
+                delegatee = value.getBinary().getStream();
+            } catch (RepositoryException re) {
+                throw (IOException) new IOException(re.getMessage()).initCause(re);
+            }
+        }
+        return delegatee;
+    }
+}

--- a/src/main/java/danta/aem/util/ResourceUtils.java
+++ b/src/main/java/danta/aem/util/ResourceUtils.java
@@ -32,8 +32,6 @@ import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.jcr.resource.JcrResourceUtil;
-import org.apache.sling.jcr.resource.internal.helper.LazyInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Fixed to run on AEM 6.5:
1. Removed org.apache.sling.jcr.resource dependency
2. Added danta.aem.util.LazyInputStream
3. Changed the version of the ACS common dependency to 4.1.0

Not, danta.aem is compatible with AEM 6.5